### PR TITLE
ci(gh-actions): add docker hub publication workflow

### DIFF
--- a/.github/workflows/push_docker_image.yml
+++ b/.github/workflows/push_docker_image.yml
@@ -1,0 +1,14 @@
+on: push
+name: push docker image
+jobs:
+  build_and_push:
+    runs-on: ubuntu-16.04
+    steps:
+      - name: checkout
+        uses: actions/checkout@v1
+      - name: login
+        run: docker login --username ${{ secrets.DOCKER_USERNAME }} --password ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+      - name: build
+        run: docker build . -t planetariumhq/nine-chronicles-http-gateway:git-${{ github.sha }}
+      - name: push (publish)
+        run: docker push planetariumhq/nine-chronicles-http-gateway:git-${{ github.sha }}

--- a/README.md
+++ b/README.md
@@ -39,6 +39,6 @@ $ dotnet run -- /rpcServerHost=aafd1af9c5cf111ea824802399f8ed0e-1178879563.ap-no
 ## Docker Build
 
 ```bash
-$ docker build . -t 319679068466.dkr.ecr.ap-northeast-2.amazonaws.com/nekoyume-unity:git-state-webapi-$(git rev-parse HEAD)
+$ docker build .
 ```
 


### PR DESCRIPTION
It makes GitHub Actions build a Docker image and publish it to *planetariumhq/nine-chronicles-http-gateway* repository in Docker Hub. The entire workflow is the same as [planetarium/libplanet-explorer].

[planetarium/libplanet-explorer]: https://github.com/planetarium/libplanet-explorer