### PR TITLE
Fix CI failure which missed submodule

### DIFF
--- a/.github/workflows/push_docker_image.yml
+++ b/.github/workflows/push_docker_image.yml
@@ -1,11 +1,18 @@
-on: push
 name: push docker image
+
+on: 
+  push:
+    branches:
+      - main
+
 jobs:
   build_and_push:
     runs-on: ubuntu-16.04
     steps:
       - name: checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
+        with:
+          submodules: true
       - name: login
         run: docker login --username ${{ secrets.DOCKER_USERNAME }} --password ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
       - name: build

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "NineChronicles.RPC.Shared"]
 	path = NineChronicles.RPC.Shared
-	url = git@github.com:planetarium/NineChronicles.RPC.Shared.git
+	url = https://github.com/planetarium/NineChronicles.RPC.Shared

--- a/README.md
+++ b/README.md
@@ -10,14 +10,14 @@ An application to provide HTTP API from NineChronicles RPC server.
 
 ## Dependencies
 
-It imports [planetarium/nekoyume-unity] repository's code as git submodule 
+It imports [planetarium/NineChronicles.RPC.Shared] repository's code as git submodule 
 because it must use RPC client created from code shared with NineChronicles RPC server.
  
 ```bash
 $ git clone --recurse-submodules git@github.com:<username>/<repository>
 ```
 
-[planetarium/nekoyume-unity]: https://github.com/planetarium/nekoyume-unity
+[planetarium/NineChronicles.RPC.Shared]: https://github.com/planetarium/NineChronicles.RPC.Shared
 
 
 ## Build


### PR DESCRIPTION
The latest [CI job](https://github.com/planetarium/NineChronicles.HttpGateway/actions/runs/228384886) failed due to missed dependecy of the submodule `NineChronicles.RPC.Shared`.